### PR TITLE
This code is for publish release applying cd

### DIFF
--- a/publish-release.yml
+++ b/publish-release.yml
@@ -1,0 +1,44 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - 'v0.0.2'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install build tools
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+
+    - name: Build distributions
+      run: |
+        python setup.py sdist bdist_wheel
+
+    - name: Create GitHub Release
+      id: create_release
+      uses: actions/create-release@v1
+      with:
+        tag_name: ${{ github.ref_name }}
+        release_name: Release ${{ github.ref_name }}
+        draft: false
+        prerelease: false
+
+    - name: Upload wheel
+      uses: actions/upload-release-asset@v1
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: dist/*.whl
+        asset_name: my_package-${{ github.ref_name }}.whl
+        asset_content_type: application/octet-stream
+


### PR DESCRIPTION
This workflow automates the publishing process for tagged releases (e.g., v0.0.2). It builds the Python package using setuptools, creates a GitHub release, and uploads the generated `.whl` file as a release asset. The workflow runs only when a tag matching the pattern 'v0.0.2' is pushed.
